### PR TITLE
Scope RpcExceptionFilter to WisdomPanelController

### DIFF
--- a/src/controllers/wisdom-panel.controller.ts
+++ b/src/controllers/wisdom-panel.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common'
+import { Controller, UseFilters } from '@nestjs/common'
 import { PROVIDER_NAME } from '../constants/provider-name'
 import {
   ApiEvent,
@@ -19,8 +19,10 @@ import {
 import { WisdomPanelService } from '../services/wisdom-panel.service'
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { MessagePattern } from '@nestjs/microservices'
+import { RpcExceptionFilter } from '../filters/rcp-exception-filter'
 
 @Controller(`engine/${PROVIDER_NAME}`)
+@UseFilters(RpcExceptionFilter)
 export class WisdomPanelController
   implements ProviderOrderCreation, ProviderReferenceData, ProviderServices
 {

--- a/src/wisdom-panel.module.ts
+++ b/src/wisdom-panel.module.ts
@@ -10,8 +10,6 @@ import { OrdersProcessor } from './processors/orders.processors'
 import { ResultsProcessor } from './processors/results.processor'
 import { CacheModule } from '@nestjs/cache-manager'
 import configuration from './config/configuration'
-import { RpcExceptionFilter } from './filters/rcp-exception-filter'
-import { APP_FILTER } from '@nestjs/core'
 import { WisdomPanelApiModule } from './wisdom-panel-api/wisdom-panel-api.module'
 
 @Module({
@@ -52,10 +50,6 @@ import { WisdomPanelApiModule } from './wisdom-panel-api/wisdom-panel-api.module
     WisdomPanelMapper,
     OrdersProcessor,
     ResultsProcessor,
-    {
-      provide: APP_FILTER,
-      useClass: RpcExceptionFilter,
-    },
   ],
   controllers: [WisdomPanelController],
   exports: [BullModule],


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
  - Moves `RpcExceptionFilter` from a global module-level filter (`APP_FILTER`) to a controller-scoped `@UseFilters()` decorator on `WisdomPanelController `                                                        
  - Ensures the filter only applies where it's needed rather than globally across the module                                                                                                                    
  - This prevents the filter from interfering with exception handling in other providers registered within the same application (e.g., other integration modules loaded by `dmi-engine`)                 

Related to: https://github.com/nominal-systems/dmi-engine-antech-v6-integration/issues/55