### PR TITLE
Bump @nominal-systems/dmi-engine-common to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/microservices": "^10.3.3",
         "@nestjs/platform-express": "^10.0.0",
-        "@nominal-systems/dmi-engine-common": "^1.1.8",
+        "@nominal-systems/dmi-engine-common": "^1.2.0",
         "axios": "^1.6.7",
         "bull": "^4.12.2",
         "cache-manager": "^5.5.1",
@@ -2111,9 +2111,9 @@
       }
     },
     "node_modules/@nominal-systems/dmi-engine-common": {
-      "version": "1.1.8",
-      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.1.8/0e9890704033437e93d6f6d695dc5030c6702a37",
-      "integrity": "sha512-+Y4LgTd+padsgr2yMnvL7Vx+YiOUTZIwbE3Y8Df1mj6wIlmM2nsZKc9dikQ+yfZKvjdnd4Xl3UWBDo8lcPM5Vw==",
+      "version": "1.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.2.0/970a29d5c0a119a903ff77cef49ba9e0a28ebbf2",
+      "integrity": "sha512-u+fZ6IvVWE2Ri92pVZ8ZZGuRIELJSFP0IezDSShcMUBWAn26hLFefhBcYEHG4DGnTu2do4nU3WLASZs8uRCSkw==",
       "license": "ISC",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.3.3",
     "@nestjs/platform-express": "^10.0.0",
-    "@nominal-systems/dmi-engine-common": "^1.1.8",
+    "@nominal-systems/dmi-engine-common": "^1.2.0",
     "axios": "^1.6.7",
     "bull": "^4.12.2",
     "cache-manager": "^5.5.1",


### PR DESCRIPTION
## Summary

Bump \`@nominal-systems/dmi-engine-common\` from \`^1.1.8\` to \`^1.2.0\`.

## Notes

Non-breaking upgrade. v1.2.0 adds compat softenings and a \`ProviderIntegrationV0\` alias; no API removals.

Closes #21