### PR TITLE
Propagate integration context for external request tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",
@@ -17,7 +17,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/microservices": "^10.3.3",
         "@nestjs/platform-express": "^10.0.0",
-        "@nominal-systems/dmi-engine-common": "^1.2.0",
+        "@nominal-systems/dmi-engine-common": "^1.3.0",
         "axios": "^1.6.7",
         "bull": "^4.12.2",
         "cache-manager": "^5.5.1",
@@ -2111,9 +2111,9 @@
       }
     },
     "node_modules/@nominal-systems/dmi-engine-common": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.2.0/970a29d5c0a119a903ff77cef49ba9e0a28ebbf2",
-      "integrity": "sha512-u+fZ6IvVWE2Ri92pVZ8ZZGuRIELJSFP0IezDSShcMUBWAn26hLFefhBcYEHG4DGnTu2do4nU3WLASZs8uRCSkw==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.3.0/acfea5ef01c6eacd6fb2cb89f7c424bd3c57817b",
+      "integrity": "sha512-c0KHPdYRz0bdGS3E1qPlXEPmHnlpFCHKA2MRx6lq1Xd//qHCl+Yd7gEtGsE0g5/UuWyDEY0iuzLhigHNYTmucw==",
       "license": "ISC",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "DMI Engine integration package for Wisdom Panel",
   "author": "Gonzalo Bellver",
   "license": "MIT",
@@ -43,7 +43,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/microservices": "^10.3.3",
     "@nestjs/platform-express": "^10.0.0",
-    "@nominal-systems/dmi-engine-common": "^1.2.0",
+    "@nominal-systems/dmi-engine-common": "^1.3.0",
     "axios": "^1.6.7",
     "bull": "^4.12.2",
     "cache-manager": "^5.5.1",

--- a/src/processors/orders.processors.ts
+++ b/src/processors/orders.processors.ts
@@ -5,7 +5,7 @@ import { WisdomPanelService } from '../services/wisdom-panel.service'
 import { ClientProxy } from '@nestjs/microservices'
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { Job } from 'bull'
-import { Order } from '@nominal-systems/dmi-engine-common'
+import { Order, runWithRequestContext } from '@nominal-systems/dmi-engine-common'
 import { ConfigService } from '@nestjs/config'
 import { debugApiEvent } from '../common/debug-utils'
 
@@ -43,37 +43,39 @@ export class OrdersProcessor {
   async fetchOrders(job: Job<WisdomPanelMessageData>) {
     const { payload, ...metadata } = job.data
 
-    try {
-      const orders: Order[] = await this.wisdomPanelService.getBatchOrders(payload, metadata)
+    await runWithRequestContext({ integrationId: payload.integrationId }, async () => {
+      try {
+        const orders: Order[] = await this.wisdomPanelService.getBatchOrders(payload, metadata)
 
-      if (orders.length > 0) {
-        this.logger.log(
-          `Fetched ${orders.length} order${orders.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
-        )
+        if (orders.length > 0) {
+          this.logger.log(
+            `Fetched ${orders.length} order${orders.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
+          )
 
-        const data = {
-          integrationId: payload.integrationId,
-          orders,
-        }
-        this.apiClient.emit('external_orders', data)
+          const data = {
+            integrationId: payload.integrationId,
+            orders,
+          }
+          this.apiClient.emit('external_orders', data)
 
-        if (this.configService.get('debug.api')) {
-          debugApiEvent('external_orders', data)
-        }
+          if (this.configService.get('debug.api')) {
+            debugApiEvent('external_orders', data)
+          }
 
-        // TODO(gb): this could be done in batch
-        for (const order of orders) {
-          if (!this.configService.get('processors.orders.dryRun')) {
-            await this.wisdomPanelService.acknowledgeOrder({ id: order.externalId }, metadata)
+          // TODO(gb): this could be done in batch
+          for (const order of orders) {
+            if (!this.configService.get('processors.orders.dryRun')) {
+              await this.wisdomPanelService.acknowledgeOrder({ id: order.externalId }, metadata)
+            }
           }
         }
+      } catch (error) {
+        this.logger.error(
+          `Error fetching orders for integration ${payload.integrationId}: ${error.message}`,
+          error.stack,
+        )
+        throw error
       }
-    } catch (error) {
-      this.logger.error(
-        `Error fetching orders for integration ${payload.integrationId}: ${error.message}`,
-        error.stack,
-      )
-      throw error
-    }
+    })
   }
 }

--- a/src/processors/results.processor.ts
+++ b/src/processors/results.processor.ts
@@ -5,6 +5,7 @@ import { WisdomPanelService } from '../services/wisdom-panel.service'
 import { ClientProxy } from '@nestjs/microservices'
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { Job } from 'bull'
+import { runWithRequestContext } from '@nominal-systems/dmi-engine-common'
 import { ConfigService } from '@nestjs/config'
 import { debugApiEvent } from '../common/debug-utils'
 
@@ -42,39 +43,41 @@ export class ResultsProcessor {
   async fetchResults(job: Job<WisdomPanelMessageData>) {
     const { payload, ...metadata } = job.data
 
-    try {
-      const batchResults = await this.wisdomPanelService.getBatchResults(payload, metadata)
+    await runWithRequestContext({ integrationId: payload.integrationId }, async () => {
+      try {
+        const batchResults = await this.wisdomPanelService.getBatchResults(payload, metadata)
 
-      if (batchResults.results.length > 0) {
-        this.logger.log(
-          `Fetched ${batchResults.results.length} result${batchResults.results.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
-        )
+        if (batchResults.results.length > 0) {
+          this.logger.log(
+            `Fetched ${batchResults.results.length} result${batchResults.results.length > 1 ? 's' : ''} for integration ${payload.integrationId}`,
+          )
 
-        const data = {
-          integrationId: payload.integrationId,
-          results: batchResults.results,
-        }
-        this.apiClient.emit('external_order_results', data)
-        this.apiClient.emit('external_results', data)
+          const data = {
+            integrationId: payload.integrationId,
+            results: batchResults.results,
+          }
+          this.apiClient.emit('external_order_results', data)
+          this.apiClient.emit('external_results', data)
 
-        if (this.configService.get('debug.api')) {
-          debugApiEvent('external_results', data)
-          debugApiEvent('external_order_results', data)
-        }
+          if (this.configService.get('debug.api')) {
+            debugApiEvent('external_results', data)
+            debugApiEvent('external_order_results', data)
+          }
 
-        // TODO(gb): this could be done in batch
-        for (const result of batchResults.results) {
-          if (!this.configService.get('processors.results.dryRun')) {
-            await this.wisdomPanelService.acknowledgeResult({ id: result.id }, metadata)
+          // TODO(gb): this could be done in batch
+          for (const result of batchResults.results) {
+            if (!this.configService.get('processors.results.dryRun')) {
+              await this.wisdomPanelService.acknowledgeResult({ id: result.id }, metadata)
+            }
           }
         }
+      } catch (error) {
+        this.logger.error(
+          `Error fetching results for integration ${payload.integrationId}: ${error.message}`,
+          error.stack,
+        )
+        throw error // Re-throw to trigger Bull retry mechanism
       }
-    } catch (error) {
-      this.logger.error(
-        `Error fetching results for integration ${payload.integrationId}: ${error.message}`,
-        error.stack,
-      )
-      throw error // Re-throw to trigger Bull retry mechanism
-    }
+    })
   }
 }

--- a/src/wisdom-panel.module.ts
+++ b/src/wisdom-panel.module.ts
@@ -1,4 +1,6 @@
 import { DynamicModule, Module } from '@nestjs/common'
+import { APP_INTERCEPTOR } from '@nestjs/core'
+import { IntegrationContextInterceptor } from '@nominal-systems/dmi-engine-common'
 import { ClientsModule, Transport } from '@nestjs/microservices'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { BullModule } from '@nestjs/bull'
@@ -55,6 +57,10 @@ import { PROVIDER_NAME } from './constants/provider-name'
     WisdomPanelMapper,
     OrdersProcessor,
     ResultsProcessor,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: IntegrationContextInterceptor,
+    },
   ],
   controllers: [WisdomPanelController],
   exports: [BullModule],


### PR DESCRIPTION
Part of nominal-systems/dmi-api#302 (PR 3c of the plan: replicates the IDEXX reference implementation, nominal-systems/dmi-engine-idexx-integration#59).

Propagates `integrationId` end-to-end through the Wisdom Panel integration so `raw_data` events (and therefore `external_requests_v2` documents) can be traced back to the originating integration and practice.

> [!NOTE]
> **Ready for review.** Common 1.3.0 is merged and published (nominal-systems/dmi-engine-common#25). `package.json` now depends on common `^1.3.0` and is bumped to version `0.3.15` (commit `1d92abe`); the yalc link was removed. CI runs against the published package — `tsc` build and all 30 unit tests pass.
>
> **After approval & merge:** this package is consumed by dmi-engine (it is *not* a standalone service), so the release is a publish, not a deploy. The version bump rides in this PR, so cutting the release only needs a tag (no direct push to `main`):
> ```bash
> git checkout main && git pull
> git tag v0.3.15 && git push origin v0.3.15
> ```
> The tag triggers `publish-package.yml` → `npm publish` of `@nominal-systems/dmi-engine-wisdom-panel-integration@0.3.15` to the GitHub Package Registry (+ a GitHub Release). The new code only runs once **dmi-engine (PR 4)** bumps its dependency to `0.3.15` and is redeployed.

## Changes

- **`wisdom-panel.module.ts`**: register `IntegrationContextInterceptor` as an `APP_INTERCEPTOR`. Covers the request/reply (MQTT) path — the interceptor extracts `data.integrationId ?? data.payload?.integrationId` from the incoming message and runs the handler inside the request-context scope.
- **`processors/orders.processors.ts`** / **`processors/results.processor.ts`**: wrap each `@Process()` body in `runWithRequestContext({ integrationId: payload.integrationId }, …)`. Covers the polling path. `payload.integrationId` already travels in the job data. The processors' `throw error` (Bull retry) still propagates through `runWithRequestContext`.
- **`package.json`**: bump `@nominal-systems/dmi-engine-common` `^1.2.0` → `^1.3.0` and version `0.3.14` → `0.3.15`.

Both paths converge on the shared `AxiosInterceptor`, which resolves `config.metadata?.integrationId ?? getRequestContext()?.integrationId` and emits it in `raw_data`. `WisdomPanelApiInterceptor` only overrides `filter` / `debug` / `extractAccessionIds`, so the base `extract()` (and its `integrationId` resolution) is inherited unchanged. All fields stay optional → backward compatible, deployable in any order.

### OAuth note

The OAuth token request (`POST /oauth/token`) is **not** in `EXCLUDED_ENDPOINTS`, so it is logged when it fires (token is cached, so only on cache miss). It runs inside the scope of whichever operation triggered the refresh, so it correctly inherits that operation's `integrationId`.

## Verification

- `npm run build` ✅ · `npm test` ✅ (30/30), against the published common 1.3.0.
- Mirrors the IDEXX (#59) and Antech V6 (nominal-systems/dmi-engine-antech-v6-integration#62) implementations, both validated end-to-end locally.

## Deploy note

Documents are only *complete* (with `practiceId`) once dmi-api's receiver (nominal-systems/dmi-api#303, commit 2) is also deployed. Engine/api deploy order is interchangeable (optional fields both ways).
