### PR TITLE
Fix CROSSSLOT errors on clustered Redis: hash-tag the Bull queue prefix

### DIFF
--- a/src/wisdom-panel.module.ts
+++ b/src/wisdom-panel.module.ts
@@ -46,8 +46,11 @@ import { PROVIDER_NAME } from './constants/provider-name'
       }),
     }),
     BullModule.registerQueue(
-      { name: `${PROVIDER_NAME}.orders` },
-      { name: `${PROVIDER_NAME}.results` },
+      // Hash-tagged prefix (same convention as the host app's queue registration) so that all
+      // keys of a queue hash to the same slot on clustered Redis; without it, Bull's multi-key
+      // Lua scripts fail with CROSSSLOT.
+      { name: `${PROVIDER_NAME}.orders`, prefix: `{${PROVIDER_NAME}.orders}` },
+      { name: `${PROVIDER_NAME}.results`, prefix: `{${PROVIDER_NAME}.results}` },
     ),
     WisdomPanelApiModule,
   ],


### PR DESCRIPTION
## Problem
In Voyager DEV, `dmiengineapi` (dmi-engine 1.5.0, this package at 0.3.16) logs continuously, ~every 5 seconds:

```
ERROR [OrdersProcessor]  Queue error: CROSSSLOT Keys in request don't hash to the same slot
ERROR [ResultsProcessor] Queue error: CROSSSLOT Keys in request don't hash to the same slot
```

## Root cause
The `BullModule.registerQueue()` call added in #20 (released as 0.3.15) has no `prefix`, so the queue instances the processors bind to use Bull's default `bull` prefix — shadowing the host app's hash-tagged registration (dmi-engine registers these same queues with `prefix: '{<queueName>}'`). On clustered Redis (Azure Cache for Redis with clustering enabled), keys like `bull:wisdom-panel.orders:delayed` and `bull:wisdom-panel.orders:wait` hash to **different slots**, so every multi-key Lua script Bull runs — notably the delayed-job guard that fires every 5 seconds (`updateDelaySet`) — is rejected with CROSSSLOT. The `@OnQueueError` handler added in the same PR is what surfaces the error in the logs.

This also explains why the sibling engines (zoetis, idexx, antech-v6) don't error against the same Redis: their integration modules don't register queues themselves, so their processors bind to the host's hash-tagged queues.

## Fix
Register the queues with the same hash-tagged `{<queueName>}` prefix convention the host app uses, so all keys of each queue colocate in one hash slot and both registrations agree on the key namespace.

## Verification
Reproduced against a local 6-node Redis cluster (grokzen/redis-cluster 7.0.10) with a Bull queue wired exactly like the app (cluster client + processor + delayed job):

- un-prefixed (current 0.3.16 behavior): **8 CROSSSLOT errors in 12s** (guard timer + addJob)
- with `prefix: '{wisdom-panel.orders}'`: **0 errors**

`npm run build` and `npm test` pass (30/30).

## Rollout note
After deploying, any stray `bull:wisdom-panel.*` keys left in the DEV cluster by the un-prefixed instances are orphaned and can be deleted manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)