### PR TITLE
Recover orders from Wisdom Panel 422 on already-activated kits

### DIFF
--- a/src/common/mapper-utils.spec.ts
+++ b/src/common/mapper-utils.spec.ts
@@ -76,6 +76,11 @@ describe('mapper-utils', () => {
       expect(petMatchesCreatePetPayload(pet, payload)).toBe(true)
     })
 
+    it('should match species regardless of casing or whitespace', () => {
+      const pet = buildPet({ name: 'Firulais', species: ' Dog ', 'owner-last-name': 'Greco' })
+      expect(petMatchesCreatePetPayload(pet, payload)).toBe(true)
+    })
+
     it('should not match a different pet name', () => {
       const pet = buildPet({ name: 'Rex', species: 'dog', 'owner-last-name': 'Greco' })
       expect(petMatchesCreatePetPayload(pet, payload)).toBe(false)

--- a/src/common/mapper-utils.spec.ts
+++ b/src/common/mapper-utils.spec.ts
@@ -1,4 +1,10 @@
-import { extractKitCode, mapNotableAndAtRiskHealthTestResults } from './mapper-utils'
+import {
+  extractKitCode,
+  mapNotableAndAtRiskHealthTestResults,
+  petMatchesCreatePetPayload,
+} from './mapper-utils'
+import { WisdomPanelCreatePetPayload } from '../interfaces/wisdom-panel-api-payloads.interface'
+import { WisdomPanelPetItem } from '../interfaces/wisdom-panel-api-responses.interface'
 
 describe('mapper-utils', () => {
   describe('extractKitCode()', () => {
@@ -47,6 +53,53 @@ describe('mapper-utils', () => {
 
       const items = mapNotableAndAtRiskHealthTestResults(results, 0)
       expect(items[0].valueString).toBe('RESOLVED_RESULT')
+    })
+  })
+  describe('petMatchesCreatePetPayload()', () => {
+    const payload = {
+      data: {
+        name: 'Firulais',
+        species: 'dog',
+        client_last_name: 'Greco',
+      },
+    } as WisdomPanelCreatePetPayload
+
+    const buildPet = (attributes: Record<string, unknown>): WisdomPanelPetItem =>
+      ({
+        id: 'pet-id-1',
+        type: 'pets',
+        attributes,
+      }) as unknown as WisdomPanelPetItem
+
+    it('should match on normalized name and species', () => {
+      const pet = buildPet({ name: '  firulais ', species: 'dog', 'owner-last-name': 'Greco' })
+      expect(petMatchesCreatePetPayload(pet, payload)).toBe(true)
+    })
+
+    it('should not match a different pet name', () => {
+      const pet = buildPet({ name: 'Rex', species: 'dog', 'owner-last-name': 'Greco' })
+      expect(petMatchesCreatePetPayload(pet, payload)).toBe(false)
+    })
+
+    it('should not match a different species', () => {
+      const pet = buildPet({ name: 'Firulais', species: 'cat', 'owner-last-name': 'Greco' })
+      expect(petMatchesCreatePetPayload(pet, payload)).toBe(false)
+    })
+
+    it('should not match when the owner last name differs', () => {
+      const pet = buildPet({ name: 'Firulais', species: 'dog', 'owner-last-name': 'Smith' })
+      expect(petMatchesCreatePetPayload(pet, payload)).toBe(false)
+    })
+
+    it('should match when the owner last name is missing on either side', () => {
+      const noOwner = buildPet({ name: 'Firulais', species: 'dog' })
+      expect(petMatchesCreatePetPayload(noOwner, payload)).toBe(true)
+
+      const payloadNoLastName = {
+        data: { name: 'Firulais', species: 'dog', client_last_name: '' },
+      } as WisdomPanelCreatePetPayload
+      const withOwner = buildPet({ name: 'Firulais', species: 'dog', 'owner-last-name': 'Greco' })
+      expect(petMatchesCreatePetPayload(withOwner, payloadNoLastName)).toBe(true)
     })
   })
 })

--- a/src/common/mapper-utils.ts
+++ b/src/common/mapper-utils.ts
@@ -209,7 +209,7 @@ export function petMatchesCreatePetPayload(
   payload: WisdomPanelCreatePetPayload,
 ): boolean {
   const nameMatches = normalizeName(pet.attributes.name) === normalizeName(payload.data.name)
-  const speciesMatches = pet.attributes.species === payload.data.species
+  const speciesMatches = normalizeName(pet.attributes.species) === normalizeName(payload.data.species)
   const ownerLastName = pet.attributes['owner-last-name']
   const lastNameMatches =
     isNullOrUndefinedOrEmpty(ownerLastName) ||

--- a/src/common/mapper-utils.ts
+++ b/src/common/mapper-utils.ts
@@ -13,7 +13,9 @@ import {
   WisdomPanelBreedPercentagesResult,
   WisdomPanelIdealWeightResult,
   WisdomPanelNotableAndAtRiskHealthTestResult,
+  WisdomPanelPetItem,
 } from '../interfaces/wisdom-panel-api-responses.interface'
+import { WisdomPanelCreatePetPayload } from '../interfaces/wisdom-panel-api-payloads.interface'
 import { KitStage } from '../interfaces/wisdom-panel-api.types'
 
 export function mapPetSpecies(species: string): 'dog' | 'cat' {
@@ -196,4 +198,23 @@ export function mapNotableAndAtRiskHealthTestResults(
   }
 
   return items
+}
+
+export function normalizeName(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function petMatchesCreatePetPayload(
+  pet: WisdomPanelPetItem,
+  payload: WisdomPanelCreatePetPayload,
+): boolean {
+  const nameMatches = normalizeName(pet.attributes.name) === normalizeName(payload.data.name)
+  const speciesMatches = pet.attributes.species === payload.data.species
+  const ownerLastName = pet.attributes['owner-last-name']
+  const lastNameMatches =
+    isNullOrUndefinedOrEmpty(ownerLastName) ||
+    isNullOrUndefinedOrEmpty(payload.data.client_last_name)
+      ? true
+      : normalizeName(ownerLastName) === normalizeName(payload.data.client_last_name)
+  return nameMatches && speciesMatches && lastNameMatches
 }

--- a/src/interfaces/wisdom-panel-api-payloads.interface.ts
+++ b/src/interfaces/wisdom-panel-api-payloads.interface.ts
@@ -26,6 +26,7 @@ export interface WisdomPanelKitFiler {
   activated?: boolean
   hospital_number?: string
   voyager_kits?: boolean
+  code?: string
 }
 
 export interface WisdomPanelResultSetsFilter {

--- a/src/services/wisdom-panel.service.spec.ts
+++ b/src/services/wisdom-panel.service.spec.ts
@@ -101,6 +101,19 @@ describe('WisdomPanelService', () => {
       })
     })
 
+    it('should wrap order payload mapping failures as provider errors', async () => {
+      const payload = {} as unknown as CreateOrderPayload
+      const metadata = {} as unknown as WisdomPanelMessageData
+      mapperMock.mapCreateOrderPayload.mockImplementation(() => {
+        throw new Error('Unexpected mapping failure')
+      })
+      await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+        message: 'Failed to create order',
+      })
+      expect(apiServiceMock.createPet).not.toHaveBeenCalled()
+      expect(apiServiceMock.getKits).not.toHaveBeenCalled()
+    })
+
     describe('422 recovery', () => {
       const payload = {} as unknown as CreateOrderPayload
       const metadata = {

--- a/src/services/wisdom-panel.service.spec.ts
+++ b/src/services/wisdom-panel.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nominal-systems/dmi-engine-common'
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { ConfigService } from '@nestjs/config'
+import { WisdomApiException } from '../exceptions/wisdom-api.exception'
 
 describe('WisdomPanelService', () => {
   let service: WisdomPanelService
@@ -80,6 +81,33 @@ describe('WisdomPanelService', () => {
         manifest: expect.objectContaining({
           data: expect.any(String),
         }),
+      })
+    })
+
+    it('should propagate the provider status code when order creation fails', async () => {
+      const payload = {} as unknown as CreateOrderPayload
+      const metadata = {} as unknown as WisdomPanelMessageData
+      apiServiceMock.createPet.mockRejectedValue(
+        new WisdomApiException('Failed to create pet', 422, new Error('Unprocessable Entity')),
+      )
+      await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+        statusCode: 422,
+      })
+    })
+  })
+
+  describe('getBatchOrders()', () => {
+    it('should propagate the provider status code when fetching kits fails', async () => {
+      const payload = {} as unknown as NullPayloadPayload
+      const metadata = {
+        integrationOptions: { hospitalNumber: '123' },
+        providerConfiguration: {},
+      } as unknown as WisdomPanelMessageData
+      apiServiceMock.getUnacknowledgedKitsForHospital.mockRejectedValue(
+        new WisdomApiException('Failed to get kits', 401, new Error('Unauthorized')),
+      )
+      await expect(service.getBatchOrders(payload, metadata)).rejects.toMatchObject({
+        statusCode: 401,
       })
     })
   })

--- a/src/services/wisdom-panel.service.spec.ts
+++ b/src/services/wisdom-panel.service.spec.ts
@@ -7,6 +7,7 @@ import {
   CreateOrderPayload,
   NullPayloadPayload,
   OrderCreatedResponse,
+  OrderStatus,
 } from '@nominal-systems/dmi-engine-common'
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { ConfigService } from '@nestjs/config'
@@ -20,6 +21,7 @@ describe('WisdomPanelService', () => {
   }
   const apiServiceMock = {
     createPet: jest.fn(),
+    getKits: jest.fn(),
     getUnacknowledgedKitsForHospital: jest.fn(),
     getUnacknowledgedResultSetsForHospital: jest.fn(),
     getSimplifiedResultSets: jest.fn(),
@@ -86,12 +88,131 @@ describe('WisdomPanelService', () => {
 
     it('should propagate the provider status code when order creation fails', async () => {
       const payload = {} as unknown as CreateOrderPayload
-      const metadata = {} as unknown as WisdomPanelMessageData
+      const metadata = {
+        integrationOptions: { hospitalNumber: '005437' },
+        providerConfiguration: {},
+      } as unknown as WisdomPanelMessageData
+      mapperMock.mapCreateOrderPayload.mockReturnValue({ data: { code: 'AAA' } })
       apiServiceMock.createPet.mockRejectedValue(
         new WisdomApiException('Failed to create pet', 422, new Error('Unprocessable Entity')),
       )
       await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
         statusCode: 422,
+      })
+    })
+
+    describe('422 recovery', () => {
+      const payload = {} as unknown as CreateOrderPayload
+      const metadata = {
+        integrationOptions: { hospitalNumber: '005437' },
+        providerConfiguration: {},
+      } as unknown as WisdomPanelMessageData
+
+      const createPetPayload = {
+        data: {
+          code: 'VRHPBBN',
+          name: 'Firulais',
+          species: 'dog',
+          client_last_name: 'Greco',
+        },
+      }
+
+      const unprocessable = new WisdomApiException(
+        'Failed to create pet',
+        422,
+        new Error('Unprocessable Entity'),
+      )
+
+      const buildKitsResponse = (
+        kitAttributes: Record<string, unknown>,
+        petAttributes?: Record<string, unknown>,
+      ) => ({
+        data: [
+          {
+            id: 'kit-id-1',
+            type: 'kits',
+            attributes: kitAttributes,
+            relationships: { pet: { data: { type: 'pets', id: 'pet-id-1' } } },
+          },
+        ],
+        included:
+          petAttributes !== undefined
+            ? [{ id: 'pet-id-1', type: 'pets', attributes: petAttributes }]
+            : [],
+      })
+
+      beforeEach(() => {
+        mapperMock.mapCreateOrderPayload.mockReturnValue(createPetPayload)
+        apiServiceMock.createPet.mockRejectedValue(unprocessable)
+      })
+
+      it('should recover the order when the kit is activated for the same pet', async () => {
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: true },
+            { name: '  firulais ', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        const response: OrderCreatedResponse = await service.createOrder(payload, metadata)
+        expect(apiServiceMock.getKits).toHaveBeenCalledWith(
+          { code: 'VRHPBBN', hospital_number: '005437' },
+          { include: 'pet,pet.owner' },
+          expect.any(Object),
+        )
+        expect(response).toEqual({
+          externalId: 'kit-id-1',
+          requisitionId: 'VRHPBBN',
+          status: OrderStatus.SUBMITTED,
+          manifest: null,
+        })
+      })
+
+      it('should fail with a clear 422 when the kit is activated for a different pet', async () => {
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: true },
+            { name: 'Rex', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        await expect(service.createOrder(payload, metadata)).rejects.toThrow(
+          /already activated for pet 'Rex'/,
+        )
+      })
+
+      it('should propagate the original 422 when no kit is found', async () => {
+        apiServiceMock.getKits.mockResolvedValue({ data: [], included: [] })
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 422,
+        })
+      })
+
+      it('should propagate the original 422 when the kit is not activated', async () => {
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: false },
+            { name: 'Firulais', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 422,
+        })
+      })
+
+      it('should propagate the original 422 when the kit lookup fails', async () => {
+        apiServiceMock.getKits.mockRejectedValue(new Error('connection refused'))
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 422,
+        })
+      })
+
+      it('should not attempt recovery for non-422 errors', async () => {
+        apiServiceMock.createPet.mockRejectedValue(
+          new WisdomApiException('Failed to create pet', 500, new Error('Internal Server Error')),
+        )
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 500,
+        })
+        expect(apiServiceMock.getKits).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -84,7 +84,7 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
         },
       }
     } catch (err) {
-      throw new WisdomApiException('Failed to create order', err.status, err)
+      throw new WisdomApiException('Failed to create order', err.statusCode ?? err.status, err)
     }
   }
 
@@ -117,7 +117,7 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
         this.logger.debug(`Found kit ${order.externalId} (kit code: ${kit.attributes.code})`)
       }
     } catch (err) {
-      throw new WisdomApiException('Failed to get batch orders', err.status, err)
+      throw new WisdomApiException('Failed to get batch orders', err.statusCode ?? err.status, err)
     }
 
     return orders

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -24,6 +24,7 @@ import {
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { WisdomPanelApiService } from '../wisdom-panel-api/wisdom-panel-api.service'
 import { WisdomPanelMapper } from '../providers/wisdom-panel-mapper'
+import { petMatchesCreatePetPayload } from '../common/mapper-utils'
 import { WisdomPanelCreatePetPayload } from '../interfaces/wisdom-panel-api-payloads.interface'
 import {
   WisdomPanelKitItem,
@@ -66,9 +67,9 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
     payload: CreateOrderPayload,
     metadata: WisdomPanelMessageData,
   ): Promise<OrderCreatedResponse> {
+    const createPetPayload: WisdomPanelCreatePetPayload =
+      this.wisdomPanelMapper.mapCreateOrderPayload(payload, metadata)
     try {
-      const createPetPayload: WisdomPanelCreatePetPayload =
-        this.wisdomPanelMapper.mapCreateOrderPayload(payload, metadata)
       const response: WisdomPanelPetCreatedResponse = await this.wisdomPanelApiService.createPet(
         createPetPayload,
         metadata.providerConfiguration,
@@ -84,8 +85,65 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
         },
       }
     } catch (err) {
+      if ((err.statusCode ?? err.status) === 422) {
+        return await this.recoverOrderFrom422(createPetPayload, metadata, err)
+      }
       throw new WisdomApiException('Failed to create order', err.statusCode ?? err.status, err)
     }
+  }
+
+  private async recoverOrderFrom422(
+    createPetPayload: WisdomPanelCreatePetPayload,
+    metadata: WisdomPanelMessageData,
+    originalError: any,
+  ): Promise<OrderCreatedResponse> {
+    const kitCode: string = createPetPayload.data.code
+    let kitsResponse: WisdomPanelKitsResponse
+    try {
+      kitsResponse = await this.wisdomPanelApiService.getKits(
+        { code: kitCode, hospital_number: metadata.integrationOptions.hospitalNumber },
+        { include: 'pet,pet.owner' },
+        metadata.providerConfiguration,
+      )
+    } catch (lookupErr) {
+      this.logger.warn(
+        `[RECOVERY] Kit lookup failed for kit code '${kitCode}' after 422: ${lookupErr.message}`,
+      )
+      throw new WisdomApiException('Failed to create order', 422, originalError)
+    }
+
+    const kit = kitsResponse?.data?.find((kit) => kit.attributes.activated)
+    if (kit === undefined) {
+      this.logger.warn(`[RECOVERY] No activated kit found for kit code '${kitCode}' after 422`)
+      throw new WisdomApiException('Failed to create order', 422, originalError)
+    }
+
+    const pet = kitsResponse.included.find((include): include is WisdomPanelPetItem => {
+      return include.type === 'pets' && include.id === kit.relationships?.pet?.data?.id
+    })
+
+    if (pet !== undefined && petMatchesCreatePetPayload(pet, createPetPayload)) {
+      this.logger.warn(
+        `[RECOVERY] Recovered order for kit code '${kitCode}' (kit id: ${kit.id}): ` +
+          `existing activation matches submitted pet '${pet.attributes.name}'`,
+      )
+      return {
+        externalId: kit.id,
+        requisitionId: kit.attributes.code,
+        status: OrderStatus.SUBMITTED,
+        manifest: null,
+      }
+    }
+
+    this.logger.warn(
+      `[RECOVERY] Kit code '${kitCode}' is activated for a different pet ` +
+        `('${pet?.attributes.name ?? 'unknown'}'), not recovering`,
+    )
+    throw new WisdomApiException(
+      `Kit '${kitCode}' is already activated for pet '${pet?.attributes.name ?? 'unknown'}'`,
+      422,
+      originalError,
+    )
   }
 
   async getBatchOrders(

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -67,9 +67,9 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
     payload: CreateOrderPayload,
     metadata: WisdomPanelMessageData,
   ): Promise<OrderCreatedResponse> {
-    const createPetPayload: WisdomPanelCreatePetPayload =
-      this.wisdomPanelMapper.mapCreateOrderPayload(payload, metadata)
+    let createPetPayload: WisdomPanelCreatePetPayload | undefined
     try {
+      createPetPayload = this.wisdomPanelMapper.mapCreateOrderPayload(payload, metadata)
       const response: WisdomPanelPetCreatedResponse = await this.wisdomPanelApiService.createPet(
         createPetPayload,
         metadata.providerConfiguration,
@@ -85,7 +85,7 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
         },
       }
     } catch (err) {
-      if ((err.statusCode ?? err.status) === 422) {
+      if (createPetPayload !== undefined && (err.statusCode ?? err.status) === 422) {
         return await this.recoverOrderFrom422(createPetPayload, metadata, err)
       }
       throw new WisdomApiException('Failed to create order', err.statusCode ?? err.status, err)


### PR DESCRIPTION
Ref #27

## What

`createOrder` now recovers from Wisdom Panel's **HTTP 422 on already-activated kits** instead of failing the order permanently. When kit activation (`POST /api/voyager/pet`) is rejected with 422, the service looks the kit up by code + hospital number and, if the existing activation matches the submitted pet, returns a recovered `SUBMITTED` order referencing the existing kit — making order creation **idempotent** against PIMS resubmissions and duplicate MQTT deliveries.

Also fixes a status-code propagation bug: `WisdomApiException` exposes `statusCode`, but `createOrder`/`getBatchOrders` re-wrapped errors reading `err.status` (always `undefined`), so Wisdom's real 422 reached Voyager as a generic **500**.

## Background

Issue #27 documents orders in ERROR state in DMI whose kits were actually activated at Wisdom Panel. Leading hypothesis (H1): Wisdom processes the activation successfully but the response arrives after dmi-api's 90s MQTT timeout, so the order is recorded as failed; when the PIMS resubmits, Wisdom rejects the second activation with 422 (its only documented cause) and the order can never succeed — even though the kit is active and results will eventually flow. The 500-instead-of-422 propagation bug hid this signal in production logs.

## Approach: recover on 422 (not verify-first)

A pre-activation existence check does not close the time-of-check/time-of-use race and taxes every happy-path call, so the 422 itself is used as the synchronization point:

1. On 422 from `createPet`, query `GET /api/v1/kits?filter[code]={code}&filter[hospital_number]={hospitalNumber}&include=pet,pet.owner` (validated against Wisdom PROD, read-only).
2. **Identity match** (`petMatchesCreatePetPayload` in `mapper-utils`): normalized pet name (trim + lowercase) + species, reinforced with owner last name only when both sides provide it.
3. Outcomes:
   - **Kit activated for the same pet** → return `{ externalId: kit.id, requisitionId: kit.code, status: SUBMITTED, manifest: null }` and log a distinctive `[RECOVERY]` warning.
   - **Kit activated for a different pet** → rethrow a descriptive 422: `Kit '{code}' is already activated for pet '{name}'`.
   - **Kit not found / not activated / lookup failed** → rethrow the original 422.
   - **Non-422 errors** → no recovery attempt; propagate as before.

### Why `manifest: null`

Wisdom Panel renders the requisition-form PDF inline in the `POST /api/voyager/pet` 201 response (Prawn) and — confirmed against their API — exposes **no endpoint to retrieve it post-activation**. Recovered orders therefore return `manifest: null` explicitly (the field is optional in `OrderCreatedResponse`) plus the `[RECOVERY]` log line. A machine-readable "recovered" flag for Voyager would require a `dmi-engine-common` change and is out of scope.

### Transparent to Voyager

Recovery is inline and synchronous within the same MQTT request/reply: Voyager only ever sees the final outcome (`SUBMITTED` or a clear 422). The only cost on the recovery path is one extra `getKits` HTTP call — versus the 90s timeout + permanent ERROR state today.

## Safety

- **No behavior change on the happy path** — recovery only triggers on 422.
- **Fail-closed identity match** — any doubt (missing pet in `included`, name/species mismatch) rethrows the original 422 rather than binding the order to the wrong kit.
- **Lookup failures degrade to the original error** — a failed `getKits` never masks the root 422.
- **Duplicate deliveries converge** — resubmissions and MQTT redeliveries resolve to the existing activation; a genuinely foreign 422 (kit activated for another pet) still surfaces as a descriptive 422.

## Tests

- Status propagation: 422 from `createPet` → `statusCode: 422`; 401 from kits polling → `statusCode: 401`.
- Identity helper: name+species match, case/whitespace-insensitive, owner-last-name reinforcement rules.
- Recovery matrix: same-pet recovery, different-pet rejection, kit not found, kit not activated, lookup failure, non-422 passthrough.
- Full suite: **43 tests, 7 suites, all passing**; `tsc` build and `eslint` clean.

## Out of scope

- Production-evidence track for the orders listed in #27 (parallel ops work) — hence `Ref #27`, not `Closes #27`.
- Machine-readable recovered flag in `OrderCreatedResponse` (requires a `dmi-engine-common` change).
