### PR TITLE
Fail fast on orders/manifest requests for post-activation orders

### DIFF
--- a/src/controllers/wisdom-panel.controller.spec.ts
+++ b/src/controllers/wisdom-panel.controller.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { PATTERN_METADATA } from '@nestjs/microservices/constants'
+import { ApiEvent, sharedSubscriptionTopic } from '@nominal-systems/dmi-engine-common'
+import { WisdomPanelController } from './wisdom-panel.controller'
+import { WisdomPanelService } from '../services/wisdom-panel.service'
+import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
+import { SHARED_SUBSCRIPTION_GROUP } from '../constants/shared-subscription-group'
+
+describe('WisdomPanelController', () => {
+  let controller: WisdomPanelController
+  const serviceMock = {
+    getManifest: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WisdomPanelController],
+      providers: [
+        {
+          provide: WisdomPanelService,
+          useValue: serviceMock,
+        },
+      ],
+    }).compile()
+
+    controller = module.get<WisdomPanelController>(WisdomPanelController)
+    jest.clearAllMocks()
+  })
+
+  describe('getOrderManifest()', () => {
+    it('should subscribe to the shared orders/manifest topic', () => {
+      const patterns = Reflect.getMetadata(
+        PATTERN_METADATA,
+        WisdomPanelController.prototype.getOrderManifest,
+      )
+      expect(patterns).toContain(
+        sharedSubscriptionTopic(SHARED_SUBSCRIPTION_GROUP, 'wisdom-panel/orders/manifest'),
+      )
+    })
+
+    it('should delegate to the service with the payload and metadata', async () => {
+      serviceMock.getManifest.mockRejectedValue(new Error('no manifest'))
+      const msg = {
+        data: {
+          payload: { id: 'kit-id-1' },
+          integrationId: 'integration-id',
+          providerConfiguration: {},
+          integrationOptions: { hospitalNumber: '005437' },
+        },
+      } as unknown as ApiEvent<WisdomPanelMessageData>
+
+      await expect(controller.getOrderManifest(msg)).rejects.toThrow('no manifest')
+      expect(serviceMock.getManifest).toHaveBeenCalledWith(
+        { id: 'kit-id-1' },
+        expect.objectContaining({ integrationId: 'integration-id' }),
+      )
+    })
+  })
+})

--- a/src/controllers/wisdom-panel.controller.ts
+++ b/src/controllers/wisdom-panel.controller.ts
@@ -3,6 +3,7 @@ import { PROVIDER_NAME } from '../constants/provider-name'
 import { SHARED_SUBSCRIPTION_GROUP } from '../constants/shared-subscription-group'
 import {
   ApiEvent,
+  Attachment,
   Breed,
   Device,
   IntegrationTestResponse,
@@ -47,6 +48,15 @@ export class WisdomPanelController
   public async createOrder(msg: ApiEvent<WisdomPanelMessageData>): Promise<OrderCreatedResponse> {
     const { payload, ...metadata } = msg.data
     return await this.wisdomPanelService.createOrder(payload, metadata)
+  }
+
+  @SharedMessagePattern(
+    SHARED_SUBSCRIPTION_GROUP,
+    `${PROVIDER_NAME}/${Resource.Orders}/${Operation.Manifest}`,
+  )
+  public async getOrderManifest(msg: ApiEvent<WisdomPanelMessageData>): Promise<Attachment> {
+    const { payload, ...metadata } = msg.data
+    return await this.wisdomPanelService.getManifest(payload, metadata)
   }
 
   @SharedMessagePattern(

--- a/src/services/wisdom-panel.service.spec.ts
+++ b/src/services/wisdom-panel.service.spec.ts
@@ -5,6 +5,7 @@ import { WisdomPanelMapper } from '../providers/wisdom-panel-mapper'
 import {
   BatchResultsResponse,
   CreateOrderPayload,
+  IdPayload,
   NullPayloadPayload,
   OrderCreatedResponse,
   OrderStatus,
@@ -227,6 +228,30 @@ describe('WisdomPanelService', () => {
         })
         expect(apiServiceMock.getKits).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('getManifest()', () => {
+    const payload = { id: 'kit-id-1' } as unknown as IdPayload
+    const metadata = {
+      integrationOptions: { hospitalNumber: '005437' },
+      providerConfiguration: {},
+    } as unknown as WisdomPanelMessageData
+
+    it('should fail fast with an explicit provider error', async () => {
+      await expect(service.getManifest(payload, metadata)).rejects.toBeInstanceOf(
+        WisdomApiException,
+      )
+      await expect(service.getManifest(payload, metadata)).rejects.toMatchObject({
+        statusCode: 404,
+        message: expect.stringContaining('cannot be retrieved afterwards'),
+      })
+    })
+
+    it('should not call the Wisdom Panel API', async () => {
+      await expect(service.getManifest(payload, metadata)).rejects.toThrow()
+      expect(apiServiceMock.getKits).not.toHaveBeenCalled()
+      expect(apiServiceMock.createPet).not.toHaveBeenCalled()
     })
   })
 

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common'
 import {
+  Attachment,
   BaseProviderService,
   BatchResultsResponse,
   Breed,
@@ -273,6 +274,19 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
 
   getOrderResult(payload: IdPayload, metadata: WisdomPanelMessageData): Promise<Result> {
     throw new Error('Method not implemented')
+  }
+
+  // Wisdom Panel renders the requisition form inline in the POST /api/voyager/pet
+  // response and exposes no endpoint to retrieve it afterwards, so orders recovered
+  // from a 422 (see recoverOrderFrom422) have no manifest. Fail fast instead of
+  // leaving the caller waiting for the MQTT timeout. If Wisdom ever exposes a
+  // retrieval endpoint, fetch the PDF here.
+  async getManifest(payload: IdPayload, metadata: WisdomPanelMessageData): Promise<Attachment> {
+    throw new WisdomApiException(
+      'The requisition form is only available at kit activation time and cannot be retrieved afterwards (Wisdom Panel API limitation)',
+      404,
+      {},
+    )
   }
 
   getServiceByCode(


### PR DESCRIPTION
Closes #29

## TL;DR — priority

**Low priority. This is preventive housekeeping, not a fix for an active problem.**

Production logs show **zero** calls to the manifest endpoint (evidence below). Nothing is broken today and nobody is being affected. What this PR does is remove a latent trap: the current failure mode is not an error response but a **~90s hang**, on an endpoint that is still published in the public API contract. Merging is cheap and zero-risk; there is no urgency behind it.

## What

Adds a `wisdom-panel/orders/manifest` message handler to `WisdomPanelController` that fails fast with an explicit `ProviderError` instead of leaving the caller waiting for the MQTT client timeout.

The service method throws a `WisdomApiException`, which the already-applied `RpcExceptionFilter` (`src/filters/rcp-exception-filter.ts:12`) converts into a `ProviderError`. No new plumbing.

## Background

After #28, `createOrder` can recover from a Wisdom Panel 422 (already-activated kit) and returns `manifest: null`, because Wisdom Panel renders the requisition-form PDF inline in the `POST /api/voyager/pet` 201 response and exposes **no endpoint to retrieve it post-activation**.

For such an order, dmi-api's `getOrderManifest` (`orders.service.ts:659-701`) publishes `wisdom-panel/orders/manifest` over MQTT — a pattern this module did not handle. With no subscriber replying, the request hung until the client timeout (~90s) and surfaced as a generic error, while holding a Fastify worker for the whole duration.

Note this shape predates #28: orders left in `ERROR` were already manifest-less. What #28 introduced is a *legitimate* case — a valid `SUBMITTED` order a PIMS has every right to query.

## Approach

```typescript
@SharedMessagePattern(
  SHARED_SUBSCRIPTION_GROUP,
  `${PROVIDER_NAME}/${Resource.Orders}/${Operation.Manifest}`,
)
public async getOrderManifest(msg: ApiEvent<WisdomPanelMessageData>): Promise<Attachment> {
  const { payload, ...metadata } = msg.data
  return await this.wisdomPanelService.getManifest(payload, metadata)
}
```

The handler follows the existing convention in `dmi-engine-idexx-integration` (`idexx.controller.ts:130`) and `dmi-engine-antech-integration` (`antech.controller.ts:163`). All scaffolding already existed in `dmi-engine-common` (`Operation.Manifest`, the `Manifest<T>` service interface, the optional `getManifest?` on `ProviderIntegration`) — no changes to the shared library.

`WisdomPanelService.getManifest()` throws with an explicit message:

> The requisition form is only available at kit activation time and cannot be retrieved afterwards (Wisdom Panel API limitation)

If Wisdom ever exposes a retrieval endpoint, this handler becomes the place to fetch and return the PDF instead of throwing. That intent is recorded in a comment on the method.

## Evidence — why this is low priority

### Code investigation

- The **only** caller of `getOrderManifest` in all of dmi-api is the public HTTP endpoint `GET /orders/:id/manifest` (`orders.controller.ts:108` → `orders.service.ts:659`). There is no internal job, processor, or creation-flow path that triggers it.
- `dmi-api-admin-ui` does not use the endpoint either (no references in `src/`).
- The endpoint **is** part of the published contract (`dmi/spec/reference/dmi.yaml:709`, `ApiKeyAuth`), so any integrated PIMS may legitimately call it — which is the argument for closing the gap at all.
- The spec already documents `404` as a valid response for this endpoint (line 717), so failing fast matches what the contract already promises.
- The endpoint has been live since dmi-api#153 (closed 2023-12-07) — roughly 2 years and 8 months.
- Since dmi-api#242 ("Attach manifest to Order", Jun 2025) the manifest travels attached to the `Order` object, making the standalone endpoint largely redundant.
- No issue in `dmi-api`, `dmi`, `dmi-engine-zoetis-integration` or `dmi-engine-antech-v6-integration` reports a hanging or timing-out manifest request — despite Zoetis returning `manifest: null` **always**, which would make any real usage of the endpoint chronically visible.

### Production logs

Measured on `voyager-prod-aks-cus-01`, namespace `prod`, across all dmi-api replicas.

**Window:** 2026-07-28 13:09 → 16:21 (~3h12m), **201,055 log lines**.
**Occurrences of `manifest`: 0.**

Positive control over the same window:

| MQTT operation | Count |
|---|---:|
| `idexx/orders/create` | 5,332 |
| `antech-v6/orders/create` | 4,305 |
| `idexx/orders/cancel` | 1,054 |
| `antech-v6/orders/cancel` | 638 |
| `wisdom-panel/orders/create` | 95 |
| **`*/orders/manifest`** | **0** |

11,424 order operations — including 95 Wisdom Panel order creations — and not a single manifest request.

Limits of this measurement, stated explicitly:

- Only the MQTT-publishing path is observable. An order that already has a manifest stored returns from the DB without logging. That case is not the problematic one, though: the failure mode addressed here (manifest-less order → hang) is exactly the one that *would* be logged, and it is zero.
- The window is ~3 hours, not months — the pod buffer does not reach further back and the previous pod retains no logs. Usage at, say, once per week would not be detected. Datadog APM (the pods run `datadog-lib-js-init`) would give the definitive long-range number.

## Caveats

- **The `404` does not reach the PIMS as a 404.** dmi-api's globally registered `AllExceptionsFilter` (`common/interceptors/all-exceptions.filter.ts:29-33`) ignores `ProviderError.response.code` and hardcodes `HttpStatus.BAD_REQUEST`, so callers receive **400** with the explicit message intact. The chosen status code is therefore only visible in the `RpcExceptionInterceptor` log line. Worth noting this also contradicts the OpenAPI spec, which declares `404` for this endpoint — but fixing it would change behaviour for *every* provider at once, so it belongs in its own issue rather than here.
- **This PR does not recover the PDF.** It converts a 90s hang plus an opaque error into an immediate, explainable one. The requisition form genuinely does not exist provider-side after activation.
- **Equivalent gaps remain in `zoetis` (returns `manifest: null` always) and `antech-v6` (`undefined` when no TRF is available).** #29 suggested optional follow-up issues for these; given measured usage of zero, replicating this handler in two more modules was deliberately skipped. If the endpoint is ever adopted by a PIMS, those become real.
- Arguably the better long-term move is to **deprecate the endpoint** rather than harden it, given zero usage and the manifest already being attached to the `Order`. Out of scope here.

## Tests

- `src/services/wisdom-panel.service.spec.ts` — the service fails fast with `statusCode: 404` and an explicit message, and never touches the Wisdom Panel API.
- `src/controllers/wisdom-panel.controller.spec.ts` (new file — the repo had no controller spec) — asserts via `PATTERN_METADATA` that the `$share/{group}/wisdom-panel/orders/manifest` topic is registered, and that the handler delegates payload and metadata correctly.

`npm test` → 49 tests passing across 8 suites. `npm run lint` and `npm run build` clean.
