### PR TITLE
Gate 422 kit activation recovery behind a Statsig feature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "class-validator": "^0.14.1",
         "moment": "^2.30.1",
         "reflect-metadata": "^0.2.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "statsig-node": "^6.5.1"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -5684,6 +5685,12 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
+    "node_modules/ip3country": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip3country/-/ip3country-5.0.0.tgz",
+      "integrity": "sha512-lcFLMFU4eO1Z7tIpbVFZkaZ5ltqpeaRx7L9NsAbA9uA7/O/rj3RF8+evE5gDitooaTTIqjdzZrenFO/OOxQ2ew==",
+      "license": "ISC"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -8650,6 +8657,34 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
+    "node_modules/statsig-node": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/statsig-node/-/statsig-node-6.5.2.tgz",
+      "integrity": "sha512-frYju9kWvHc61SkjisIe7/d6GCZd0a3zrL1P88rJl1fD6JB73AnoAd9cd1GUNcECzDth7l4UzPGvlJykI9fBvg==",
+      "license": "ISC",
+      "dependencies": {
+        "ip3country": "^5.0.0",
+        "node-fetch": "^2.7.0",
+        "ua-parser-js": "^1.0.2",
+        "uuid": "^11.1.1"
+      },
+      "engines": {
+        "pnpm": "never"
+      }
+    },
+    "node_modules/statsig-node/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -9355,6 +9390,32 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/uid": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "class-validator": "^0.14.1",
     "moment": "^2.30.1",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "statsig-node": "^6.5.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/feature-flags/env-feature-flag.provider.ts
+++ b/src/feature-flags/env-feature-flag.provider.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common'
+import {
+  WISDOM_PANEL_ACTIVATED_KIT_RECOVERY,
+  type FeatureFlagContext,
+  type FeatureFlagProvider,
+} from './feature-flag.interface'
+
+@Injectable()
+export class EnvFeatureFlagProvider implements FeatureFlagProvider {
+  isEnabled(flag: string, _context?: FeatureFlagContext): boolean {
+    switch (flag) {
+      case WISDOM_PANEL_ACTIVATED_KIT_RECOVERY:
+        return process.env.WISDOM_PANEL_ACTIVATED_KIT_RECOVERY === 'true'
+      default:
+        return false
+    }
+  }
+}

--- a/src/feature-flags/feature-flag.interface.ts
+++ b/src/feature-flags/feature-flag.interface.ts
@@ -1,0 +1,14 @@
+export const FEATURE_FLAG_PROVIDER = 'FEATURE_FLAG_PROVIDER'
+
+export interface FeatureFlagContext {
+  userID?: string
+  clinicId?: string
+  integrationId?: string
+  custom?: Record<string, unknown>
+}
+
+export interface FeatureFlagProvider {
+  isEnabled(flag: string, context?: FeatureFlagContext): boolean
+}
+
+export const WISDOM_PANEL_ACTIVATED_KIT_RECOVERY = 'dmi_wisdom_panel_activated_kit_recovery'

--- a/src/feature-flags/statsig-feature-flag.provider.ts
+++ b/src/feature-flags/statsig-feature-flag.provider.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import Statsig from 'statsig-node'
+import { type FeatureFlagContext, type FeatureFlagProvider } from './feature-flag.interface'
+
+@Injectable()
+export class StatsigFeatureFlagProvider implements FeatureFlagProvider, OnModuleInit {
+  private readonly logger = new Logger(StatsigFeatureFlagProvider.name)
+  private initialized = false
+
+  private getStringValue(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined
+    }
+
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  }
+
+  async onModuleInit() {
+    const secretKey = process.env.STATSIG_SERVER_SECRET_KEY
+    if (!secretKey) {
+      this.logger.warn('STATSIG_SERVER_SECRET_KEY not set, Statsig disabled')
+      return
+    }
+
+    try {
+      await Statsig.initialize(secretKey, {
+        environment: { tier: process.env.STATSIG_ENVIRONMENT || 'development' },
+      })
+      this.initialized = true
+      this.logger.log('Statsig initialized successfully')
+    } catch (error) {
+      this.logger.error('Failed to initialize Statsig', error)
+    }
+  }
+
+  isEnabled(flag: string, context?: FeatureFlagContext): boolean {
+    if (!this.initialized) {
+      this.logger.debug(`Statsig not initialized, flag "${flag}" returning false (legacy path)`)
+      return false
+    }
+
+    const custom = context?.custom ?? {}
+    const resolvedClinicId =
+      this.getStringValue(context?.clinicId) ||
+      this.getStringValue(custom.clinicId) ||
+      this.getStringValue(custom.clinicid)
+    const resolvedIntegrationId =
+      this.getStringValue(context?.integrationId) ||
+      this.getStringValue(custom.integrationId) ||
+      this.getStringValue(custom.integrationid)
+    const resolvedUserId =
+      this.getStringValue(context?.userID) ||
+      resolvedClinicId ||
+      resolvedIntegrationId ||
+      'anonymous'
+
+    const user = {
+      userID: resolvedUserId,
+      custom: {
+        ...custom,
+        clinicId: resolvedClinicId,
+        integrationId: resolvedIntegrationId,
+      },
+    }
+
+    const result = Statsig.checkGate(user, flag)
+
+    this.logger.debug(
+      `Flag "${flag}" for clinicId=${resolvedClinicId}, integrationId=${resolvedIntegrationId}, userID=${resolvedUserId}: ${result}`,
+    )
+
+    return result
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
 export * from './wisdom-panel.module'
+export * from './feature-flags/feature-flag.interface'
+export * from './feature-flags/statsig-feature-flag.provider'
+export * from './feature-flags/env-feature-flag.provider'

--- a/src/services/wisdom-panel.service.spec.ts
+++ b/src/services/wisdom-panel.service.spec.ts
@@ -12,9 +12,15 @@ import {
 import { WisdomPanelMessageData } from '../interfaces/wisdom-panel-message-data.interface'
 import { ConfigService } from '@nestjs/config'
 import { WisdomApiException } from '../exceptions/wisdom-api.exception'
+import {
+  FEATURE_FLAG_PROVIDER,
+  WISDOM_PANEL_ACTIVATED_KIT_RECOVERY,
+  type FeatureFlagProvider,
+} from '../feature-flags/feature-flag.interface'
 
 describe('WisdomPanelService', () => {
   let service: WisdomPanelService
+  let featureFlagProviderMock: jest.Mocked<FeatureFlagProvider>
   const mapperMock = {
     mapCreateOrderPayload: jest.fn(),
     mapWisdomPanelResult: jest.fn(),
@@ -31,6 +37,9 @@ describe('WisdomPanelService', () => {
   }
 
   beforeEach(async () => {
+    featureFlagProviderMock = {
+      isEnabled: jest.fn().mockReturnValue(false),
+    }
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WisdomPanelService,
@@ -47,6 +56,10 @@ describe('WisdomPanelService', () => {
         {
           provide: WisdomPanelMapper,
           useValue: mapperMock,
+        },
+        {
+          provide: FEATURE_FLAG_PROVIDER,
+          useValue: featureFlagProviderMock,
         },
       ],
     }).compile()
@@ -99,6 +112,7 @@ describe('WisdomPanelService', () => {
       await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
         statusCode: 422,
       })
+      expect(apiServiceMock.getKits).not.toHaveBeenCalled()
     })
 
     it('should wrap order payload mapping failures as provider errors', async () => {
@@ -157,6 +171,7 @@ describe('WisdomPanelService', () => {
       beforeEach(() => {
         mapperMock.mapCreateOrderPayload.mockReturnValue(createPetPayload)
         apiServiceMock.createPet.mockRejectedValue(unprocessable)
+        featureFlagProviderMock.isEnabled.mockReturnValue(true)
       })
 
       it('should recover the order when the kit is activated for the same pet', async () => {
@@ -167,6 +182,10 @@ describe('WisdomPanelService', () => {
           ),
         )
         const response: OrderCreatedResponse = await service.createOrder(payload, metadata)
+        expect(featureFlagProviderMock.isEnabled).toHaveBeenCalledWith(
+          WISDOM_PANEL_ACTIVATED_KIT_RECOVERY,
+          expect.objectContaining({ clinicId: '005437' }),
+        )
         expect(apiServiceMock.getKits).toHaveBeenCalledWith(
           { code: 'VRHPBBN', hospital_number: '005437' },
           { include: 'pet,pet.owner' },
@@ -178,6 +197,14 @@ describe('WisdomPanelService', () => {
           status: OrderStatus.SUBMITTED,
           manifest: null,
         })
+      })
+
+      it('should not attempt recovery when the flag is disabled', async () => {
+        featureFlagProviderMock.isEnabled.mockReturnValue(false)
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 422,
+        })
+        expect(apiServiceMock.getKits).not.toHaveBeenCalled()
       })
 
       it('should fail with a clear 422 when the kit is activated for a different pet', async () => {

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common'
 import {
   BaseProviderService,
   BatchResultsResponse,
@@ -35,6 +35,11 @@ import {
 } from '../interfaces/wisdom-panel-api-responses.interface'
 import { ConfigService } from '@nestjs/config'
 import { WisdomApiException } from '../exceptions/wisdom-api.exception'
+import {
+  FEATURE_FLAG_PROVIDER,
+  WISDOM_PANEL_ACTIVATED_KIT_RECOVERY,
+  type FeatureFlagProvider,
+} from '../feature-flags/feature-flag.interface'
 
 @Injectable()
 export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageData> {
@@ -44,6 +49,9 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
     private readonly configService: ConfigService,
     private readonly wisdomPanelApiService: WisdomPanelApiService,
     private readonly wisdomPanelMapper: WisdomPanelMapper,
+    @Optional()
+    @Inject(FEATURE_FLAG_PROVIDER)
+    private readonly featureFlags?: FeatureFlagProvider,
   ) {
     super()
   }
@@ -86,7 +94,15 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
       }
     } catch (err) {
       if (createPetPayload !== undefined && (err.statusCode ?? err.status) === 422) {
-        return await this.recoverOrderFrom422(createPetPayload, metadata, err)
+        const recoveryEnabled =
+          this.featureFlags?.isEnabled(WISDOM_PANEL_ACTIVATED_KIT_RECOVERY, {
+            clinicId: metadata.integrationOptions.hospitalNumber,
+            integrationId: metadata.integrationId,
+          }) ?? false
+
+        if (recoveryEnabled) {
+          return await this.recoverOrderFrom422(createPetPayload, metadata, err)
+        }
       }
       throw new WisdomApiException('Failed to create order', err.statusCode ?? err.status, err)
     }

--- a/src/wisdom-panel.module.spec.ts
+++ b/src/wisdom-panel.module.spec.ts
@@ -1,0 +1,31 @@
+import { Provider } from '@nestjs/common'
+import { WisdomPanelModule } from './wisdom-panel.module'
+import { FEATURE_FLAG_PROVIDER } from './feature-flags/feature-flag.interface'
+
+describe('WisdomPanelModule.register()', () => {
+  it('should not register a feature-flag provider by default', () => {
+    const module = WisdomPanelModule.register()
+
+    expect(module.providers).toEqual([])
+  })
+
+  it('should register the feature-flag provider supplied by the host', () => {
+    const featureFlagProvider: Provider = {
+      provide: FEATURE_FLAG_PROVIDER,
+      useValue: { isEnabled: () => true },
+    }
+
+    const module = WisdomPanelModule.register({ featureFlagProvider })
+
+    expect(module.providers).toEqual([featureFlagProvider])
+  })
+
+  it('should forward imports and extra providers', () => {
+    const extraProvider: Provider = { provide: 'TOKEN', useValue: 'value' }
+
+    const module = WisdomPanelModule.register({ providers: [extraProvider] })
+
+    expect(module.providers).toEqual([extraProvider])
+    expect(module.imports).toEqual([])
+  })
+})

--- a/src/wisdom-panel.module.ts
+++ b/src/wisdom-panel.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module } from '@nestjs/common'
+import { DynamicModule, Module, ModuleMetadata, Provider } from '@nestjs/common'
 import { APP_INTERCEPTOR } from '@nestjs/core'
 import { IntegrationContextInterceptor } from '@nominal-systems/dmi-engine-common'
 import { ClientsModule, Transport } from '@nestjs/microservices'
@@ -14,6 +14,8 @@ import { CacheModule } from '@nestjs/cache-manager'
 import configuration from './config/configuration'
 import { WisdomPanelApiModule } from './wisdom-panel-api/wisdom-panel-api.module'
 import { PROVIDER_NAME } from './constants/provider-name'
+import { FEATURE_FLAG_PROVIDER } from './feature-flags/feature-flag.interface'
+import { StatsigFeatureFlagProvider } from './feature-flags/statsig-feature-flag.provider'
 
 @Module({
   imports: [
@@ -69,9 +71,21 @@ import { PROVIDER_NAME } from './constants/provider-name'
   exports: [BullModule],
 })
 export class WisdomPanelModule {
-  static register(): DynamicModule {
+  static register(options: WisdomPanelModuleOptions = {}): DynamicModule {
+    const featureFlagProvider: Provider =
+      options.featureFlagProvider ??
+      ({ provide: FEATURE_FLAG_PROVIDER, useClass: StatsigFeatureFlagProvider } satisfies Provider)
+
     return {
       module: WisdomPanelModule,
+      imports: [...(options.imports ?? [])],
+      providers: [featureFlagProvider, ...(options.providers ?? [])],
     }
   }
+}
+
+export interface WisdomPanelModuleOptions {
+  imports?: ModuleMetadata['imports']
+  providers?: Provider[]
+  featureFlagProvider?: Provider
 }

--- a/src/wisdom-panel.module.ts
+++ b/src/wisdom-panel.module.ts
@@ -14,8 +14,6 @@ import { CacheModule } from '@nestjs/cache-manager'
 import configuration from './config/configuration'
 import { WisdomPanelApiModule } from './wisdom-panel-api/wisdom-panel-api.module'
 import { PROVIDER_NAME } from './constants/provider-name'
-import { FEATURE_FLAG_PROVIDER } from './feature-flags/feature-flag.interface'
-import { StatsigFeatureFlagProvider } from './feature-flags/statsig-feature-flag.provider'
 
 @Module({
   imports: [
@@ -71,15 +69,16 @@ import { StatsigFeatureFlagProvider } from './feature-flags/statsig-feature-flag
   exports: [BullModule],
 })
 export class WisdomPanelModule {
+  // No default feature-flag provider: one declared here would shadow the host's and boot a second
+  // Statsig SDK. Opt in explicitly; without it, gates read as disabled.
   static register(options: WisdomPanelModuleOptions = {}): DynamicModule {
-    const featureFlagProvider: Provider =
-      options.featureFlagProvider ??
-      ({ provide: FEATURE_FLAG_PROVIDER, useClass: StatsigFeatureFlagProvider } satisfies Provider)
-
     return {
       module: WisdomPanelModule,
       imports: [...(options.imports ?? [])],
-      providers: [featureFlagProvider, ...(options.providers ?? [])],
+      providers: [
+        ...(options.featureFlagProvider !== undefined ? [options.featureFlagProvider] : []),
+        ...(options.providers ?? []),
+      ],
     }
   }
 }


### PR DESCRIPTION
Closes #33

## What

Wraps the 422 kit activation recovery logic from #28 (order recovery on already-activated kits) behind the Statsig gate `dmi_wisdom_panel_activated_kit_recovery`, so it can be rolled out per-hospital and disabled instantly without redeploying. The status-code propagation fix from #28 stays unconditionally enabled.

Related engine-side wiring: [nominal-systems/dmi-engine#72](https://github.com/nominal-systems/dmi-engine/pull/72).

## Background

#28 is already merged and published (0.3.18), so this PR gates already-deployed behavior. Wisdom runs as a module of dmi-engine, which already initializes Statsig once via `StatsigFeatureFlagsService`. To avoid a second `Statsig.initialize()` in the same process, the module consumes the host-provided `FEATURE_FLAG_PROVIDER` — the same wiring Antech V6 already uses.

## Approach

- Adds `src/feature-flags/` mirroring the `dmi-engine-antech-v6-integration` pattern:
  - `feature-flag.interface.ts` — `FEATURE_FLAG_PROVIDER` token, `FeatureFlagContext`, `FeatureFlagProvider`, `WISDOM_PANEL_ACTIVATED_KIT_RECOVERY = dmi_wisdom_panel_activated_kit_recovery`.
  - `statsig-feature-flag.provider.ts` — provider for standalone runs (falls back to legacy path when `STATSIG_SERVER_SECRET_KEY` is unset).
  - `env-feature-flag.provider.ts` — env-var fallback for local/tests.
- `WisdomPanelModule.register(options)` now accepts `featureFlagProvider` and `imports`; exports the feature-flags module from `src/index.ts`.
- `WisdomPanelService.createOrder` evaluates the gate (context: `clinicId = integrationOptions.hospitalNumber`, `integrationId`) and only calls `recoverOrderFrom422` when the gate is on; `err.statusCode ?? err.status` propagation remains always active.
- Adds `statsig-node` dependency.

## No default feature-flag provider

`register()` deliberately registers **no** feature-flag provider unless the caller supplies one.

Defaulting to `useClass: StatsigFeatureFlagProvider` looked convenient but was a trap. Nest resolves a token from the module's own providers first, then imports, then `@Global()` modules. A provider declared by `register()` therefore *shadows* the one exported by the host's global `FeatureFlagsModule`, and because `useClass` instantiates the class, its `onModuleInit()` fires a second `Statsig.initialize()` against the SDK's process-wide singleton — exactly the invariant this PR is meant to preserve. Nothing in the signature forced a host to pass its own provider, so `register()` with no arguments compiled fine and would only fail at runtime, silently.

It is also unnecessary: the host's module is `@Global()` and already exports the token, so `WisdomPanelService`'s `@Optional()` injection resolves to the host provider anyway. Standalone `main.ts` uses `NestFactory.create(WisdomPanelModule)` directly and never goes through `register()` at all.

With no provider supplied, the injection resolves to `undefined` and `?.isEnabled(...) ?? false` reads as disabled — fail-closed, the right default for a flag. Standalone runs that want Statsig opt in explicitly:

```ts
WisdomPanelModule.register({
  featureFlagProvider: { provide: FEATURE_FLAG_PROVIDER, useClass: StatsigFeatureFlagProvider }
})
```

## Safety

- Flag off / no Statsig secret: behavior is #28 minus recovery — the 422 propagates with its real status code and the order stays in ERROR. No `getKits` call is made.
- Flag on: current #28 recovery behavior.
- Single Statsig initialization in the process (host-owned provider when running inside dmi-engine).

## Tests

- Unit tests: recovery matrix kept (flag on); new regression asserting the gate disables recovery (flag off → 422 propagates, `getKits` not called); flag context asserted (`clinicId` = hospital number).
- New `wisdom-panel.module.spec.ts` pins the `register()` contract: no provider by default, host-supplied provider forwarded, extra imports/providers passed through.
- `npm run lint`, `npm test` (49 passing), `npm run build` clean.

## Caveats

- Requires creating the gate (`dmi_wisdom_panel_activated_kit_recovery`) in the Statsig console at rollout 0%, segmented by hospital (rule on custom field `clinicId` = hospital number), and the engine-side PR with the version bump + `register({ featureFlagProvider })` wiring.
- The engine-side PR also carries the fix that actually makes `clinicId` reach Statsig; without it the gate can only be toggled globally.
