### PR TITLE
Release 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-  "version": "0.3.18",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-      "version": "0.3.18",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-  "version": "0.3.18",
+  "version": "0.4.0",
   "description": "DMI Engine integration package for Wisdom Panel",
   "author": "Gonzalo Bellver",
   "license": "MIT",


### PR DESCRIPTION
## What

Bumps the package version to `0.4.0`.

## Background

The `v0.4.0` tag was pushed and the package published, but branch protection rejected the direct `main` push that `npm version` performs in its `postversion` hook. This PR carries the version bump that `main` is missing so the repository state matches the published package.

## Scope

`package.json` / `package-lock.json` version fields only — no source changes.

Follows #34.