### PR TITLE
Add requisition form retrieval to the order recovery path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ boot a second Statsig SDK instance.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `dmi_wisdom_panel_activated_kit_recovery` | off | When the Wisdom Panel API rejects an order with `422` because the kit is already activated, look the kit up and recover the order if the existing activation matches the pet being submitted. If it belongs to a different pet, or no activated kit is found, the `422` is propagated as before. |
+| `dmi_wisdom_panel_activated_kit_recovery` | off | When the Wisdom Panel API rejects an order with `422` because the kit is already activated, look the kit up and recover the order if the existing activation matches the pet being submitted. The requisition form is then retrieved with `GET /api/voyager/pet`, which requires the `voyager_pet_id` sent at activation: a `422` there means the kit belongs to a different patient and the recovery is aborted, while any other failure still recovers the order without a manifest. If the kit belongs to a different pet, or no activated kit is found, the `422` is propagated as before. |
 
 Flags are evaluated with `clinicId` (the integration's `hospitalNumber`) and `integrationId`, so
 rules can target a specific clinic.

--- a/src/interfaces/wisdom-panel-api-endpoints.interface.ts
+++ b/src/interfaces/wisdom-panel-api-endpoints.interface.ts
@@ -4,7 +4,7 @@ export enum WisdomPanelApiEndpoints {
   GET_RESULT_SETS = '/api/v1/result-sets',
   GET_SIMPLIFIED_RESULT_SETS = '/api/voyager/banfield-results-retrieval',
   GET_REPORT_PDF = '/pdf-generator/vet-report',
-  CREATE_PET = '/api/voyager/pet',
+  VOYAGER_PET = '/api/voyager/pet',
   ACKNOWLEDGE_KITS = '/api/voyager/acknowledge-kits',
   ACKNOWLEDGE_RESULT_SETS = '/api/voyager/acknowledge-result-sets',
 }

--- a/src/interfaces/wisdom-panel-api-responses.interface.ts
+++ b/src/interfaces/wisdom-panel-api-responses.interface.ts
@@ -9,7 +9,7 @@ export interface OAuthTokenResponse {
   created_at: number
 }
 
-export interface WisdomPanelPetCreatedResponse {
+export interface WisdomPanelPetResponse {
   message: string
   data: {
     pet: WisdomPanelPet

--- a/src/services/wisdom-panel.service.spec.ts
+++ b/src/services/wisdom-panel.service.spec.ts
@@ -27,6 +27,7 @@ describe('WisdomPanelService', () => {
   }
   const apiServiceMock = {
     createPet: jest.fn(),
+    getPet: jest.fn(),
     getKits: jest.fn(),
     getUnacknowledgedKitsForHospital: jest.fn(),
     getUnacknowledgedResultSetsForHospital: jest.fn(),
@@ -141,6 +142,7 @@ describe('WisdomPanelService', () => {
           name: 'Firulais',
           species: 'dog',
           client_last_name: 'Greco',
+          voyager_pet_id: '434956978',
         },
       }
 
@@ -171,6 +173,14 @@ describe('WisdomPanelService', () => {
       beforeEach(() => {
         mapperMock.mapCreateOrderPayload.mockReturnValue(createPetPayload)
         apiServiceMock.createPet.mockRejectedValue(unprocessable)
+        apiServiceMock.getPet.mockResolvedValue({
+          message: 'success',
+          data: {
+            pet: { id: 'pet-id-1', name: 'Firulais' },
+            kit: { id: 'kit-id-1', code: 'VRHPBBN' },
+            requisition_form: 'base64 pdf',
+          },
+        })
         featureFlagProviderMock.isEnabled.mockReturnValue(true)
       })
 
@@ -191,6 +201,69 @@ describe('WisdomPanelService', () => {
           { include: 'pet,pet.owner' },
           expect.any(Object),
         )
+        expect(apiServiceMock.getPet).toHaveBeenCalledWith(
+          'VRHPBBN',
+          '434956978',
+          expect.any(Object),
+        )
+        expect(response).toEqual({
+          externalId: 'kit-id-1',
+          requisitionId: 'VRHPBBN',
+          status: OrderStatus.SUBMITTED,
+          manifest: {
+            contentType: 'application/pdf',
+            data: 'base64 pdf',
+          },
+        })
+      })
+
+      it('should not recover when Wisdom Panel does not match the kit to the submitted patient', async () => {
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: true },
+            { name: 'Firulais', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        apiServiceMock.getPet.mockRejectedValue(
+          new WisdomApiException(
+            'Failed to get pet',
+            422,
+            new Error('WIS_VOY__105: Failed: Kit VRHPBBN could not be found.'),
+          ),
+        )
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 422,
+          message: "Kit 'VRHPBBN' is activated for a different patient than the one submitted",
+        })
+      })
+
+      it('should not recover when the order carries no patient id', async () => {
+        mapperMock.mapCreateOrderPayload.mockReturnValue({
+          data: { ...createPetPayload.data, voyager_pet_id: '' },
+        })
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: true },
+            { name: 'Firulais', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
+          statusCode: 422,
+        })
+        expect(apiServiceMock.getPet).not.toHaveBeenCalled()
+      })
+
+      it('should recover without a manifest when the requisition form cannot be fetched', async () => {
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: true },
+            { name: 'Firulais', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        apiServiceMock.getPet.mockRejectedValue(
+          new WisdomApiException('Failed to get pet', 429, new Error('Too Many Requests')),
+        )
+        const response: OrderCreatedResponse = await service.createOrder(payload, metadata)
         expect(response).toEqual({
           externalId: 'kit-id-1',
           requisitionId: 'VRHPBBN',
@@ -199,12 +272,28 @@ describe('WisdomPanelService', () => {
         })
       })
 
+      it('should recover without a manifest when the response carries no requisition form', async () => {
+        apiServiceMock.getKits.mockResolvedValue(
+          buildKitsResponse(
+            { code: 'VRHPBBN', activated: true },
+            { name: 'Firulais', species: 'dog', 'owner-last-name': 'Greco' },
+          ),
+        )
+        apiServiceMock.getPet.mockResolvedValue({
+          message: 'success',
+          data: { pet: {}, kit: { id: 'kit-id-1', code: 'VRHPBBN' } },
+        })
+        const response: OrderCreatedResponse = await service.createOrder(payload, metadata)
+        expect(response.manifest).toBeNull()
+      })
+
       it('should not attempt recovery when the flag is disabled', async () => {
         featureFlagProviderMock.isEnabled.mockReturnValue(false)
         await expect(service.createOrder(payload, metadata)).rejects.toMatchObject({
           statusCode: 422,
         })
         expect(apiServiceMock.getKits).not.toHaveBeenCalled()
+        expect(apiServiceMock.getPet).not.toHaveBeenCalled()
       })
 
       it('should fail with a clear 422 when the kit is activated for a different pet', async () => {
@@ -217,6 +306,7 @@ describe('WisdomPanelService', () => {
         await expect(service.createOrder(payload, metadata)).rejects.toThrow(
           /already activated for pet 'Rex'/,
         )
+        expect(apiServiceMock.getPet).not.toHaveBeenCalled()
       })
 
       it('should propagate the original 422 when no kit is found', async () => {

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common'
 import {
+  Attachment,
   BaseProviderService,
   BatchResultsResponse,
   Breed,
@@ -9,6 +10,7 @@ import {
   FileUtils,
   IdPayload,
   IntegrationTestResponse,
+  isNullOrUndefinedOrEmpty,
   NullPayloadPayload,
   Order,
   OrderCreatedResponse,
@@ -29,7 +31,7 @@ import { WisdomPanelCreatePetPayload } from '../interfaces/wisdom-panel-api-payl
 import {
   WisdomPanelKitItem,
   WisdomPanelKitsResponse,
-  WisdomPanelPetCreatedResponse,
+  WisdomPanelPetResponse,
   WisdomPanelPetItem,
   WisdomPanelResultSetsResponse,
 } from '../interfaces/wisdom-panel-api-responses.interface'
@@ -78,7 +80,7 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
     let createPetPayload: WisdomPanelCreatePetPayload | undefined
     try {
       createPetPayload = this.wisdomPanelMapper.mapCreateOrderPayload(payload, metadata)
-      const response: WisdomPanelPetCreatedResponse = await this.wisdomPanelApiService.createPet(
+      const response: WisdomPanelPetResponse = await this.wisdomPanelApiService.createPet(
         createPetPayload,
         metadata.providerConfiguration,
       )
@@ -139,15 +141,17 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
     })
 
     if (pet !== undefined && petMatchesCreatePetPayload(pet, createPetPayload)) {
+      const manifest = await this.fetchRecoveredManifest(createPetPayload, metadata, originalError)
       this.logger.warn(
         `[RECOVERY] Recovered order for kit code '${kitCode}' (kit id: ${kit.id}): ` +
-          `existing activation matches submitted pet '${pet.attributes.name}'`,
+          `existing activation matches submitted pet '${pet.attributes.name}'` +
+          `${manifest === null ? ' (requisition form unavailable)' : ''}`,
       )
       return {
         externalId: kit.id,
         requisitionId: kit.attributes.code,
         status: OrderStatus.SUBMITTED,
-        manifest: null,
+        manifest,
       }
     }
 
@@ -160,6 +164,66 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
       422,
       originalError,
     )
+  }
+
+  /**
+   * Retrieves the requisition form of an already-activated kit.
+   *
+   * Wisdom Panel only returns it when the `voyager_pet_id` sent at activation matches the one
+   * stored on the pet, so a 422 here means the activation on record does not belong to the patient
+   * being resubmitted: the recovery is aborted and the original 422 propagated. Any other failure
+   * (throttling, transport, provider outage) says nothing about identity, so the order is still
+   * recovered — without a manifest, as before this endpoint existed.
+   */
+  private async fetchRecoveredManifest(
+    createPetPayload: WisdomPanelCreatePetPayload,
+    metadata: WisdomPanelMessageData,
+    originalError: any,
+  ): Promise<Attachment | null> {
+    const kitCode: string = createPetPayload.data.code
+    const voyagerPetId: string = createPetPayload.data.voyager_pet_id
+
+    if (isNullOrUndefinedOrEmpty(voyagerPetId)) {
+      this.logger.warn(
+        `[RECOVERY] Cannot verify the activation of kit '${kitCode}': the order carries no patient id`,
+      )
+      throw new WisdomApiException('Failed to create order', 422, originalError)
+    }
+
+    let response: WisdomPanelPetResponse
+    try {
+      response = await this.wisdomPanelApiService.getPet(
+        kitCode,
+        voyagerPetId,
+        metadata.providerConfiguration,
+      )
+    } catch (err) {
+      if ((err.statusCode ?? err.status) === 422) {
+        this.logger.warn(
+          `[RECOVERY] Kit '${kitCode}' is not activated for patient '${voyagerPetId}', not recovering`,
+        )
+        throw new WisdomApiException(
+          `Kit '${kitCode}' is activated for a different patient than the one submitted`,
+          422,
+          originalError,
+        )
+      }
+      this.logger.warn(
+        `[RECOVERY] Could not retrieve the requisition form for kit '${kitCode}': ${err.message}`,
+      )
+      return null
+    }
+
+    const requisitionForm = response?.data?.requisition_form
+    if (isNullOrUndefinedOrEmpty(requisitionForm)) {
+      this.logger.warn(`[RECOVERY] Wisdom Panel returned no requisition form for kit '${kitCode}'`)
+      return null
+    }
+
+    return {
+      contentType: 'application/pdf',
+      data: requisitionForm,
+    }
   }
 
   async getBatchOrders(

--- a/src/services/wisdom-panel.service.ts
+++ b/src/services/wisdom-panel.service.ts
@@ -167,13 +167,8 @@ export class WisdomPanelService extends BaseProviderService<WisdomPanelMessageDa
   }
 
   /**
-   * Retrieves the requisition form of an already-activated kit.
-   *
-   * Wisdom Panel only returns it when the `voyager_pet_id` sent at activation matches the one
-   * stored on the pet, so a 422 here means the activation on record does not belong to the patient
-   * being resubmitted: the recovery is aborted and the original 422 propagated. Any other failure
-   * (throttling, transport, provider outage) says nothing about identity, so the order is still
-   * recovered — without a manifest, as before this endpoint existed.
+   * Fetches the requisition form of an already-activated kit. Wisdom Panel only returns it when the
+   * `voyager_pet_id` matches the pet on record, so a 422 means the kit belongs to another patient.
    */
   private async fetchRecoveredManifest(
     createPetPayload: WisdomPanelCreatePetPayload,

--- a/src/wisdom-panel-api/wisdom-panel-api.interceptor.spec.ts
+++ b/src/wisdom-panel-api/wisdom-panel-api.interceptor.spec.ts
@@ -40,4 +40,21 @@ describe('WisdomPanelApiInterceptor.filter', () => {
       expect(result).toBe(true)
     })
   })
+
+  describe('extractAccessionIds', () => {
+    it('takes the kit code from the request body when a kit is activated', () => {
+      const res = {
+        config: { method: 'post', data: JSON.stringify({ data: { code: 'VKDZHKS' } }) },
+      } as any
+      const ids = interceptor.extractAccessionIds(WisdomPanelApiEndpoints.VOYAGER_PET, {}, res)
+      expect(ids).toEqual(['VKDZHKS'])
+    })
+
+    it('takes the kit code from the response body when an order is retrieved', () => {
+      const body = { data: { kit: { code: 'VKDZHKS' }, requisition_form: 'base64 pdf' } }
+      const res = { config: { method: 'get' } } as any
+      const ids = interceptor.extractAccessionIds(WisdomPanelApiEndpoints.VOYAGER_PET, body, res)
+      expect(ids).toEqual(['VKDZHKS'])
+    })
+  })
 })

--- a/src/wisdom-panel-api/wisdom-panel-api.interceptor.ts
+++ b/src/wisdom-panel-api/wisdom-panel-api.interceptor.ts
@@ -43,8 +43,7 @@ export class WisdomPanelApiInterceptor extends AxiosInterceptor {
     const accessionIds: string[] = []
 
     if (url.includes(WisdomPanelApiEndpoints.VOYAGER_PET)) {
-      // The same path serves the activation (POST, kit code in the request body) and the
-      // order retrieval (GET, kit code in the response body)
+      // POST carries the kit code in the request body, GET in the response body
       if (response.config.method?.toLowerCase() === 'get') {
         if (body?.data?.kit?.code !== undefined) {
           accessionIds.push(body.data.kit.code)

--- a/src/wisdom-panel-api/wisdom-panel-api.interceptor.ts
+++ b/src/wisdom-panel-api/wisdom-panel-api.interceptor.ts
@@ -42,10 +42,18 @@ export class WisdomPanelApiInterceptor extends AxiosInterceptor {
   public extractAccessionIds(url: string, body: any, response: AxiosResponse): string[] {
     const accessionIds: string[] = []
 
-    if (url.includes(WisdomPanelApiEndpoints.CREATE_PET)) {
-      const payload: any = JSON.parse(response.config.data)
-      if (payload.data.code !== undefined) {
-        accessionIds.push(payload.data.code)
+    if (url.includes(WisdomPanelApiEndpoints.VOYAGER_PET)) {
+      // The same path serves the activation (POST, kit code in the request body) and the
+      // order retrieval (GET, kit code in the response body)
+      if (response.config.method?.toLowerCase() === 'get') {
+        if (body?.data?.kit?.code !== undefined) {
+          accessionIds.push(body.data.kit.code)
+        }
+      } else {
+        const payload: any = JSON.parse(response.config.data)
+        if (payload.data.code !== undefined) {
+          accessionIds.push(payload.data.code)
+        }
       }
     } else if (url.includes(WisdomPanelApiEndpoints.GET_KITS)) {
       body.data.forEach((kit: any) => {

--- a/src/wisdom-panel-api/wisdom-panel-api.service.spec.ts
+++ b/src/wisdom-panel-api/wisdom-panel-api.service.spec.ts
@@ -117,4 +117,46 @@ describe('WisdomPanelApiService', () => {
       await expect(service.authenticate(configMock)).rejects.toThrowError()
     })
   })
+
+  describe('getPet', () => {
+    const petResponseMock = {
+      message: 'success',
+      data: {
+        pet: { id: 'pet-id' },
+        kit: { id: 'kit-id', code: 'VKDZHKS' },
+        requisition_form: 'base64 pdf',
+      },
+    }
+
+    beforeEach(() => {
+      jest.spyOn(cacheManager, 'get').mockReturnValue('mockAccessToken')
+    })
+
+    it('should query the kit code and the voyager pet id', async () => {
+      jest.spyOn(httpService, 'get').mockReturnValue(httpResponseMock(200, 'OK', petResponseMock))
+      const response = await service.getPet('VKDZHKS', '434956978', configMock)
+      expect(httpService.get).toHaveBeenCalledWith(
+        `${configMock.baseUrl}/api/voyager/pet`,
+        expect.objectContaining({
+          params: { kit_code: 'VKDZHKS', voyager_pet_id: '434956978' },
+          headers: expect.objectContaining({ Authorization: 'Bearer mockAccessToken' }),
+        }),
+      )
+      expect(response).toEqual(petResponseMock)
+    })
+
+    it('should surface the provider status code when the request fails', async () => {
+      jest.spyOn(httpService, 'get').mockImplementation(() => {
+        return throwError(() => ({
+          response: {
+            status: 422,
+            data: { message: 'WIS_VOY__105: Failed: Kit VKDZHKS could not be found.' },
+          },
+        }))
+      })
+      await expect(service.getPet('VKDZHKS', 'wrong-pet-id', configMock)).rejects.toMatchObject({
+        statusCode: 422,
+      })
+    })
+  })
 })

--- a/src/wisdom-panel-api/wisdom-panel-api.service.ts
+++ b/src/wisdom-panel-api/wisdom-panel-api.service.ts
@@ -11,7 +11,7 @@ import {
   OAuthTokenResponse,
   WisdomPanelKitItem,
   WisdomPanelKitsResponse,
-  WisdomPanelPetCreatedResponse,
+  WisdomPanelPetResponse,
   WisdomPanelResultSetsResponse,
   WisdomPanelSimpleResultResponse,
 } from '../interfaces/wisdom-panel-api-responses.interface'
@@ -212,7 +212,7 @@ export class WisdomPanelApiService extends BaseApiService {
   async createPet(
     payload: WisdomPanelCreatePetPayload,
     config: WisdomPanelApiConfig,
-  ): Promise<WisdomPanelPetCreatedResponse> {
+  ): Promise<WisdomPanelPetResponse> {
     try {
       const token = await this.authenticate(config)
       const reqConfig = {
@@ -222,12 +222,38 @@ export class WisdomPanelApiService extends BaseApiService {
         },
       }
       return await this.post(
-        `${config.baseUrl}${WisdomPanelApiEndpoints.CREATE_PET}`,
+        `${config.baseUrl}${WisdomPanelApiEndpoints.VOYAGER_PET}`,
         payload,
         reqConfig,
       )
     } catch (err) {
       throw new WisdomApiException('Failed to create pet', err.status, err)
+    }
+  }
+
+  async getPet(
+    kitCode: string,
+    voyagerPetId: string,
+    config: WisdomPanelApiConfig,
+  ): Promise<WisdomPanelPetResponse> {
+    try {
+      const token = await this.authenticate(config)
+      const reqConfig = {
+        params: {
+          kit_code: kitCode,
+          voyager_pet_id: voyagerPetId,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      }
+      return await this.get<WisdomPanelPetResponse>(
+        `${config.baseUrl}${WisdomPanelApiEndpoints.VOYAGER_PET}`,
+        reqConfig,
+      )
+    } catch (err) {
+      throw new WisdomApiException('Failed to get pet', err.status, err)
     }
   }
 


### PR DESCRIPTION
## What

Recovered orders now carry the requisition form instead of `manifest: null`. Wisdom Panel shipped
the order-retrieval endpoint this issue was waiting for, so `recoverOrderFrom422` fetches the form
for the already-activated kit and returns it as the order manifest.

Closes #32.

## Background

On the happy path the requisition form only exists inside the `POST /api/voyager/pet` 201 response
(rendered inline with Prawn), so orders recovered from a 422 by #28 came back without a manifest —
see the escalation summarised in #27.

Wisdom Panel has now exposed it on **TEST/DEV**:

```
GET /api/voyager/pet?kit_code={kit_code}&voyager_pet_id={voyager_pet_id}
```

Read-only, idempotent, rate limited to 30 req/min, and it answers **only** when the
`voyager_pet_id` sent at activation matches the one stored on the pet. That id is exactly what the
recovery path already holds in `createPetPayload.data.voyager_pet_id` (`extractPetId`, the PIMS
`pims:patient:id`), so no extra bookkeeping is needed. The response shape is identical to the
activation 201.

## Approach

- `WisdomPanelApiService.getPet(kitCode, voyagerPetId, config)` calls the endpoint.
- `WisdomPanelService.fetchRecoveredManifest()` runs inside `recoverOrderFrom422`, right where the
  hardcoded `manifest: null` used to be, and is therefore covered by the existing
  `dmi_wisdom_panel_activated_kit_recovery` gate — no new flag, no second evaluation.
- The kit lookup by `filter[code]` + `filter[hospital_number]` and the pet identity check
  (`petMatchesCreatePetPayload`) stay as they are: they produce the actionable error message
  ("kit already activated for pet X") that the endpoint's deliberately generic 422 cannot.
- `CREATE_PET` → `VOYAGER_PET` and `WisdomPanelPetCreatedResponse` → `WisdomPanelPetResponse`: the
  same path and the same payload shape now serve both the activation and the retrieval. Neither
  name is part of the module's public exports.
- `WisdomPanelApiInterceptor.extractAccessionIds` used to `JSON.parse(response.config.data)` for
  anything matching `/api/voyager/pet`, which is `undefined` on a GET. It now reads the kit code
  from the response body when the verb is GET.

## Safety

A 422 from the retrieval means Wisdom Panel cannot tie the activation on record to the patient
being resubmitted, so the recovery is aborted and the 422 propagated — the endpoint doubles as a
provider-side identity check on top of ours, ensuring the simulated resubmit is bound to the same
study. Any other failure (throttling, transport, provider outage) says nothing about identity, so
the order is still recovered with `manifest: null`, exactly as before this endpoint existed. Kits
are physical and single-use; losing the PDF must never cost one.

Behaviour with the gate off is unchanged.

## Tests

`npm test` (57), `npm run build` and `npm run lint` are green. New unit tests cover the recovered
manifest, the 422 abort, the missing patient id, a throttled retrieval, a response without a form,
and both verbs in the interceptor.

Verified against Wisdom **staging** with kit `VKDZHKS` (hospital 6001, pet id `434956978`):

| Case | Result |
|---|---|
| Valid `kit_code` + `voyager_pet_id` | 200, base64 → valid 13.6 KB PDF (Antech requisition, `Req. No: VKDZHKS`), byte-identical across calls |
| Wrong `voyager_pet_id` / unknown kit / kit not activated | 422 `WIS_VOY__105` |
| Missing query params | 422 `WIS_VOY__100` |
| No token | 401 `WIS_VOY__001` |

End-to-end through `createOrder` against staging (same POST that 422s on the activated kit):
recovery with the original patient id returns `SUBMITTED` + the PDF manifest; with a different
patient id it fails with 422; with the gate off the original 422 is propagated untouched. Also
exercised end-to-end through a local dmi-api + dmi-engine.

## Caveats

Two deviations from Wisdom Panel's README worth raising with them (they do not affect this change,
which treats every 422 from the retrieval the same way):

- `WIS_VOY__105` is reused: "Model validations failed" for the activation, "kit could not be found"
  for the retrieval.
- A kit code without the `V` prefix returns `WIS_VOY__105`, not the documented `WIS_VOY__103`.

The endpoint is only confirmed on TEST/DEV, so the gate should stay off in production until Wisdom
Panel confirms it is deployed there.
