### PR TITLE
0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nominal-systems/dmi-engine-wisdom-panel-integration",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "DMI Engine integration package for Wisdom Panel",
   "author": "Gonzalo Bellver",
   "license": "MIT",


### PR DESCRIPTION
Version bump for release.

Publishes the requisition form retrieval added to the order recovery path in #37 as `0.5.0` (minor: new capability, not a fix to 0.4.0).

Once merged, `v0.5.0` is tagged from `main` so the run is titled `0.5.0`, consistent with previous releases.